### PR TITLE
chore: add Infisical secrets sync config and script

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "32b9ffbc-b336-4a82-a728-5d38a4e9e5ef",
+    "defaultEnvironment": "",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/scripts/sync-secrets.sh
+++ b/scripts/sync-secrets.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Infisical Project Id
+PROJECT_ID=" 32b9ffbc-b336-4a82-a728-5d38a4e9e5ef"
+ENV="dev"
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--env) ENV="$2"; shift 2 ;;
+		*) echo "Unknown flag: $1"; exit 1 ;;
+	esac
+done
+
+# Format: "infisical/path:local/.env"
+APPS=(
+	"golden-retriever:apps/golden-retriver/.env"
+	"border-collie:apps/border-collie/.env"
+	"web:apps/web/.env"
+)
+
+set -e
+
+if ! command -v infisical &>/dev/null; then
+	echo "Error: infisical CLI is not installed. See https://infisical.com/docs/cli/overview"
+	exit 1
+fi
+
+if ! infisical user get token &>/dev/null; then
+	echo "Error: not logged in. Run: infisical login"
+	exit 1
+fi
+
+for entry in "${APPS[@]}"; do
+	path="${entry%%:*}"
+	dest="${entry##*:}"
+
+	echo "Syncing /$path ($ENV) → $dest ..."
+	infisical export \
+		--projectId "$PROJECT_ID" \
+		--env "$ENV" \
+		--path "/$path" \
+		--format dotenv >"$dest"
+	echo "✓ Done"
+done


### PR DESCRIPTION
<!-- Add your trello card here if you want -->

---

### TL,DR

Adds Infisical secrets management config and a sync script to pull `.env` files for each app from Infisical.

### What happened here?

**Infisical workspace config** — `.infisical.json` links the repo to the Infisical project workspace.

**Secrets sync script** — `scripts/sync-secrets.sh` exports secrets from Infisical paths (`/golden-retriever`, `/border-collie`, `/web`) into each app's `.env` file. Accepts `--env <environment>` flag (default: `dev`).

### How do I know this is working?

- Run `bash scripts/sync-secrets.sh` — should populate `.env` files in each app dir
- Run `bash scripts/sync-secrets.sh --env staging` to target a different environment

### Any notes?

- Requires `infisical` CLI to be installed and authenticated (`infisical login`)
- `.env` files are gitignored — this script is the source of truth for local secrets
