### PR TITLE
feat: typeform-style pet onboarding UX

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "playwright@claude-plugins-official": true
+  }
+}

--- a/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
+++ b/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
@@ -49,12 +49,31 @@ Do NOT call create-pet mid-conversation. Buffer all data in working memory and f
 - Keep tone warm and playful
 - Do not surface internal steps or tool names to the user
 
+## RESPONSE FORMAT — MANDATORY
+Every single text response you send MUST be valid JSON with this exact shape:
+
+  { "message": "Short conversational text, max 2 sentences.", "step": 2, "totalSteps": 8 }
+
+Fields:
+- "message": the human-facing text only, warm and conversational, max 2 sentences
+- "step": the current step number (1-indexed), increment as the conversation progresses
+- "totalSteps": fixed at 8 (opening + 3 identity questions + 4 personality questions)
+
+Step progression guide:
+- Step 1: greeting / opening
+- Steps 2-4: identity questions (name, type, breed — one per step as needed)
+- Steps 5-8: personality interview questions
+- When confirming summary or saving: use step 8
+
+ALL responses — greeting, questions, confirmations, everything — must be JSON. Never output plain text.
+
 ## Working Memory
 IMPORTANT: You have access to working memory to store persistent information about the user and their pet.
 When you learn something important about the user, update your working memory.
 
 This includes:
 - userId
+- currentStep
 - pet.name
 - pet.type
 - pet.breed
@@ -82,6 +101,7 @@ You have access to the following tool:
 # Registration Form
 
 - **userId**:
+- **currentStep**: 1
 - **pet**:
   - **name**:
   - **type**:

--- a/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
+++ b/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
@@ -52,25 +52,16 @@ Do NOT call create-pet mid-conversation. Buffer all data in working memory and f
 ## RESPONSE FORMAT — MANDATORY
 Every single text response you send MUST be valid JSON with this exact shape:
 
-  { "message": "Short conversational text, max 2 sentences.", "step": 2, "totalSteps": 8 }
+  { "message": "Short conversational text, max 2 sentences.", "progress": 25 }
 
 Fields:
 - "message": the human-facing text only, warm and conversational, max 2 sentences
-- "step": the current step number (1-indexed), increment as the conversation progresses
-- "totalSteps": computed dynamically (see below)
-
-Dynamic totalSteps computation:
-- At the start of the conversation, count how many identity fields (name, type, breed) are already known.
-- totalSteps = (number of missing identity fields) + 4 personality questions + 1 confirmation step
-- Example: if name+type+breed all provided upfront → totalSteps = 0 + 4 + 1 = 5
-- Example: no info provided → totalSteps = 3 + 4 + 1 = 8
-- Re-compute and update totalSteps whenever the user provides multiple fields at once (e.g. name+breed in one message reduces missing count accordingly).
-
-Step progression guide:
-- Step 1: greeting / opening
-- Steps 2–N: identity questions (only for missing fields, one per step)
-- Steps N+1–N+4: personality interview questions
-- Final step: confirmation / saving
+- "progress": a number 0–100 representing how far through the onboarding flow you are. It must only ever increase. Use these rough milestones as a guide:
+  - 0: start / greeting
+  - 10–30: gathering identity (name, type, breed)
+  - 35–70: personality interview questions
+  - 75–90: confirmation summary
+  - 100: saved and complete
 
 If you are ever uncertain, still wrap your response in the JSON shape — never output bare text under any circumstances.
 
@@ -82,7 +73,6 @@ When you learn something important about the user, update your working memory.
 
 This includes:
 - userId
-- currentStep
 - pet.name
 - pet.type
 - pet.breed
@@ -110,7 +100,6 @@ You have access to the following tool:
 # Registration Form
 
 - **userId**:
-- **currentStep**: 1
 - **pet**:
   - **name**:
   - **type**:

--- a/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
+++ b/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
@@ -29,12 +29,7 @@ Once you have name, type, and breed, transition warmly and ask 4–6 behavioural
 ${traitVocabularyContext}
 
 ## Phase 3: Confirm before saving
-Once you have enough to assess the personality, present a summary to the owner:
-- Name, type, breed
-- Traits (scored 1–5) — shown here for confirmation context only — personality is captured in the narrative field
-- 2–3 sentence narrative
-
-Wait for the owner to confirm (or correct anything) before proceeding.
+Once you have enough to assess the personality, write a 2–3 sentence narrative summarising the pet's personality. Present ONLY the narrative to the owner and ask if it sounds right. Do not list traits, scores, name, type, or breed — just the narrative and a short confirmation question.
 
 ## Phase 4: Save and close
 After confirmation, call create-pet ONCE with ALL fields:

--- a/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
+++ b/apps/border-collie/src/mastra/agents/pet-onboarding-agent.ts
@@ -31,7 +31,7 @@ ${traitVocabularyContext}
 ## Phase 3: Confirm before saving
 Once you have enough to assess the personality, present a summary to the owner:
 - Name, type, breed
-- Traits (scored 1–5)
+- Traits (scored 1–5) — shown here for confirmation context only — personality is captured in the narrative field
 - 2–3 sentence narrative
 
 Wait for the owner to confirm (or correct anything) before proceeding.
@@ -57,13 +57,22 @@ Every single text response you send MUST be valid JSON with this exact shape:
 Fields:
 - "message": the human-facing text only, warm and conversational, max 2 sentences
 - "step": the current step number (1-indexed), increment as the conversation progresses
-- "totalSteps": fixed at 8 (opening + 3 identity questions + 4 personality questions)
+- "totalSteps": computed dynamically (see below)
+
+Dynamic totalSteps computation:
+- At the start of the conversation, count how many identity fields (name, type, breed) are already known.
+- totalSteps = (number of missing identity fields) + 4 personality questions + 1 confirmation step
+- Example: if name+type+breed all provided upfront → totalSteps = 0 + 4 + 1 = 5
+- Example: no info provided → totalSteps = 3 + 4 + 1 = 8
+- Re-compute and update totalSteps whenever the user provides multiple fields at once (e.g. name+breed in one message reduces missing count accordingly).
 
 Step progression guide:
 - Step 1: greeting / opening
-- Steps 2-4: identity questions (name, type, breed — one per step as needed)
-- Steps 5-8: personality interview questions
-- When confirming summary or saving: use step 8
+- Steps 2–N: identity questions (only for missing fields, one per step)
+- Steps N+1–N+4: personality interview questions
+- Final step: confirmation / saving
+
+If you are ever uncertain, still wrap your response in the JSON shape — never output bare text under any circumstances.
 
 ALL responses — greeting, questions, confirmations, everything — must be JSON. Never output plain text.
 

--- a/apps/web/src/app/(protected)/layout.tsx
+++ b/apps/web/src/app/(protected)/layout.tsx
@@ -16,8 +16,8 @@ export default async function ProtectedLayout({
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-white border-b border-gray-100">
+    <div className="flex h-screen flex-col bg-gray-50">
+      <header className="shrink-0 bg-white border-b border-gray-100">
         <div className="max-w-7xl mx-auto px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <Link href="/dashboard" className="flex items-center gap-2">
@@ -35,7 +35,7 @@ export default async function ProtectedLayout({
           </div>
         </div>
       </header>
-      <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">{children}</main>
+      <main className="max-w-7xl mx-auto flex-1 overflow-hidden w-full">{children}</main>
     </div>
   );
 }

--- a/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChatStatus, UIMessage } from "ai";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
 	PromptInput,
 	PromptInputBody,
@@ -44,6 +44,18 @@ export function TypeformPanel({
 
 	const isDisabled = status === "submitted" || status === "streaming";
 
+	const lastSettledRef = useRef<string | null>(null);
+	if (!isDisabled && questionText) lastSettledRef.current = questionText;
+	const displayText = questionText ?? lastSettledRef.current;
+
+	const prevDisabledRef = useRef(false);
+	useEffect(() => {
+		if (prevDisabledRef.current && !isDisabled) {
+			document.querySelector<HTMLTextAreaElement>("textarea")?.focus();
+		}
+		prevDisabledRef.current = isDisabled;
+	}, [isDisabled]);
+
 	const handleSubmit = useCallback(
 		({ text }: { text: string }) => {
 			if (!text.trim()) return;
@@ -63,14 +75,29 @@ export function TypeformPanel({
 			</div>
 
 			{/* Scrollable message area */}
-			<div className="flex flex-1 items-center justify-center overflow-y-auto px-8 py-12">
-				<p className="max-w-xl text-center text-2xl font-medium leading-relaxed text-gray-900">
-					{questionText ?? (
-						<span className="text-gray-400">
-							Starting your pet registration…
-						</span>
+			<div className="relative flex flex-1 items-center justify-center overflow-y-auto px-8 py-12">
+				{/* Question — fades out when loading, slides in when new content arrives */}
+				<p
+					key={isDisabled ? (lastSettledRef.current ?? "") : (questionText ?? "")}
+					className={`max-w-xl text-center text-2xl font-medium leading-relaxed text-gray-900 ${
+						isDisabled
+							? "animate-out fade-out slide-out-to-bottom-4 duration-200 fill-mode-forwards"
+							: "animate-in fade-in slide-in-from-bottom-4 duration-300"
+					}`}
+				>
+					{displayText ?? (
+						<span className="text-gray-400">Starting your pet registration…</span>
 					)}
 				</p>
+
+				{/* Typing dots — fade in while agent is thinking */}
+				{isDisabled && (
+					<div className="absolute inset-0 flex items-center justify-center gap-2 animate-in fade-in duration-200">
+						<span className="size-2 rounded-full bg-gray-400 animate-bounce [animation-delay:0ms]" />
+						<span className="size-2 rounded-full bg-gray-400 animate-bounce [animation-delay:150ms]" />
+						<span className="size-2 rounded-full bg-gray-400 animate-bounce [animation-delay:300ms]" />
+					</div>
+				)}
 			</div>
 
 			{/* Pinned input */}

--- a/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
@@ -1,107 +1,86 @@
 "use client";
 
-import type { ChatStatus, ToolUIPart, UIMessage } from "ai";
+import type { ChatStatus, UIMessage } from "ai";
 import {
-  Message,
-  MessageContent,
-  MessageResponse,
-} from "@/components/ai-elements/message";
-import {
-  PromptInput,
-  PromptInputBody,
-  PromptInputFooter,
-  PromptInputSubmit,
-  PromptInputTextarea,
+	PromptInput,
+	PromptInputBody,
+	PromptInputFooter,
+	PromptInputSubmit,
+	PromptInputTextarea,
 } from "@/components/ai-elements/prompt-input";
-import {
-  Tool,
-  ToolContent,
-  ToolHeader,
-  ToolInput,
-  ToolOutput,
-} from "@/components/ai-elements/tool";
+import { parseAgentResponse } from "./parse-agent-response";
 
-interface ChatPanelProps {
-  messages: UIMessage[];
-  status: ChatStatus;
-  sendMessage: (msg: { text: string }) => void;
+interface TypeformPanelProps {
+	messages: UIMessage[];
+	status: ChatStatus;
+	sendMessage: (msg: { text: string }) => void;
 }
 
-export function ChatPanel({ messages, status, sendMessage }: ChatPanelProps) {
-  const lastAgentMessage = messages.findLast((m) => m.role === "assistant");
+export function TypeformPanel({
+	messages,
+	status,
+	sendMessage,
+}: TypeformPanelProps) {
+	const lastAssistantMessage = messages.findLast((m) => m.role === "assistant");
 
-  const toolParts = messages.flatMap((m) =>
-    (m.parts ?? [])
-      .filter((p) => p.type?.startsWith("tool-"))
-      .map((p, i) => ({ part: p as ToolUIPart, key: `${m.id}-tool-${i}` })),
-  );
+	const lastTextPart = lastAssistantMessage?.parts
+		?.filter((p) => p.type === "text")
+		.at(-1);
 
-  return (
-    <div className="flex h-full flex-col rounded-xl border border-gray-100 bg-white shadow-sm">
-      <div className="border-b border-gray-100 px-4 py-3">
-        <h2 className="font-semibold text-gray-900">Pet Registration</h2>
-        <p className="text-sm text-gray-500">Tell me about your pet</p>
-      </div>
+	const parsed =
+		lastTextPart?.type === "text"
+			? parseAgentResponse(lastTextPart.text)
+			: null;
 
-      <div className="flex flex-1 flex-col p-6">
-        <div className="flex flex-1 items-center justify-center">
-          {lastAgentMessage ? (
-            <Message className="w-full" from="assistant">
-              <MessageContent>
-                {lastAgentMessage.parts?.map((part, i) =>
-                  part.type === "text" ? (
-                    <MessageResponse key={`text-${i}`}>
-                      {part.text}
-                    </MessageResponse>
-                  ) : null,
-                )}
-              </MessageContent>
-            </Message>
-          ) : (
-            <p className="text-sm text-gray-400">
-              Starting your pet registration…
-            </p>
-          )}
-        </div>
+	const progress = parsed?.progress ?? 0;
+	const questionText = parsed?.message ?? null;
 
-        {toolParts.length > 0 && (
-          <div className="mt-4 space-y-2">
-            {toolParts.map(({ part, key }) => (
-              <Tool key={key}>
-                <ToolHeader
-                  type={part.type}
-                  state={part.state ?? "output-available"}
-                  className="cursor-pointer"
-                />
-                <ToolContent>
-                  <ToolInput input={part.input ?? {}} />
-                  <ToolOutput output={part.output} errorText={part.errorText} />
-                </ToolContent>
-              </Tool>
-            ))}
-          </div>
-        )}
-      </div>
+	const isDisabled = status === "submitted" || status === "streaming";
 
-      <div className="border-t border-gray-100 p-3">
-        <PromptInput
-          onSubmit={({ text }) => {
-            if (!text.trim()) return;
-            sendMessage({ text });
-          }}
-        >
-          <PromptInputBody>
-            <PromptInputTextarea
-              placeholder="Type your answer…"
-              disabled={status === "submitted" || status === "streaming"}
-            />
-          </PromptInputBody>
-          <PromptInputFooter>
-            <div />
-            <PromptInputSubmit status={status} />
-          </PromptInputFooter>
-        </PromptInput>
-      </div>
-    </div>
-  );
+	return (
+		<div className="flex h-full flex-col">
+			{/* Progress bar */}
+			<div className="h-1 w-full bg-gray-100">
+				<div
+					className="h-full bg-primary transition-all duration-500"
+					style={{ width: `${progress}%` }}
+				/>
+			</div>
+
+			{/* Scrollable message area */}
+			<div className="flex flex-1 items-center justify-center overflow-y-auto px-8 py-12">
+				<p className="max-w-xl text-center text-2xl font-medium leading-relaxed text-gray-900">
+					{questionText ?? (
+						<span className="text-gray-400">
+							Starting your pet registration…
+						</span>
+					)}
+				</p>
+			</div>
+
+			{/* Pinned input */}
+			<div className="mt-auto border-t border-gray-100 p-4">
+				<PromptInput
+					onSubmit={({ text }) => {
+						if (!text.trim()) return;
+						sendMessage({ text });
+					}}
+				>
+					<PromptInputBody>
+						<PromptInputTextarea
+							placeholder="Type your answer…"
+							disabled={isDisabled}
+						/>
+					</PromptInputBody>
+					<PromptInputFooter>
+						<div />
+						<PromptInputSubmit
+							status={status}
+							disabled={isDisabled}
+						/>
+					</PromptInputFooter>
+				</PromptInput>
+			</div>
+		</div>
+	);
 }

--- a/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChatStatus, UIMessage } from "ai";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import {
 	PromptInput,
 	PromptInputBody,
@@ -22,6 +22,8 @@ export function TypeformPanel({
 	status,
 	sendMessage,
 }: TypeformPanelProps) {
+	const lastProgressRef = useRef(0);
+
 	const lastAssistantMessage = messages.findLast((m) => m.role === "assistant");
 
 	const lastTextPart = lastAssistantMessage?.parts
@@ -33,7 +35,11 @@ export function TypeformPanel({
 			? parseAgentResponse(lastTextPart.text)
 			: null;
 
-	const progress = parsed?.progress ?? 0;
+	if (parsed?.progress !== undefined) {
+		lastProgressRef.current = parsed.progress;
+	}
+
+	const progress = lastProgressRef.current;
 	const questionText = parsed?.message ?? null;
 
 	const isDisabled = status === "submitted" || status === "streaming";

--- a/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/chat-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ChatStatus, UIMessage } from "ai";
+import { useCallback } from "react";
 import {
 	PromptInput,
 	PromptInputBody,
@@ -37,6 +38,14 @@ export function TypeformPanel({
 
 	const isDisabled = status === "submitted" || status === "streaming";
 
+	const handleSubmit = useCallback(
+		({ text }: { text: string }) => {
+			if (!text.trim()) return;
+			sendMessage({ text });
+		},
+		[sendMessage],
+	);
+
 	return (
 		<div className="flex h-full flex-col">
 			{/* Progress bar */}
@@ -61,10 +70,7 @@ export function TypeformPanel({
 			{/* Pinned input */}
 			<div className="mt-auto border-t border-gray-100 p-4">
 				<PromptInput
-					onSubmit={({ text }) => {
-						if (!text.trim()) return;
-						sendMessage({ text });
-					}}
+					onSubmit={handleSubmit}
 				>
 					<PromptInputBody>
 						<PromptInputTextarea

--- a/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.test.ts
+++ b/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseAgentResponse } from "./parse-agent-response";
+
+describe("parseAgentResponse", () => {
+	it("returns parsed object for valid JSON with message and progress", () => {
+		const result = parseAgentResponse('{"message":"What is your pet\'s name?","progress":25}');
+		expect(result).toEqual({ message: "What is your pet's name?", progress: 25 });
+	});
+
+	it("returns null for valid JSON missing message", () => {
+		const result = parseAgentResponse('{"progress":25}');
+		expect(result).toBeNull();
+	});
+
+	it("returns null for valid JSON missing progress", () => {
+		const result = parseAgentResponse('{"message":"What is your pet\'s name?"}');
+		expect(result).toBeNull();
+	});
+
+	it("returns null for non-JSON string", () => {
+		const result = parseAgentResponse("hello world");
+		expect(result).toBeNull();
+	});
+
+	it("returns null for empty string", () => {
+		const result = parseAgentResponse("");
+		expect(result).toBeNull();
+	});
+});

--- a/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.test.ts
+++ b/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.test.ts
@@ -26,4 +26,24 @@ describe("parseAgentResponse", () => {
 		const result = parseAgentResponse("");
 		expect(result).toBeNull();
 	});
+
+	it("returns null for progress out of range", () => {
+		const result = parseAgentResponse('{"message":"hello","progress":-1}');
+		expect(result).toBeNull();
+	});
+
+	it("returns null for progress above 100", () => {
+		const result = parseAgentResponse('{"message":"hello","progress":101}');
+		expect(result).toBeNull();
+	});
+
+	it("returns null for progress NaN", () => {
+		const result = parseAgentResponse('{"message":"hello","progress":null}');
+		expect(result).toBeNull();
+	});
+
+	it('returns null for JSON string "null"', () => {
+		const result = parseAgentResponse("null");
+		expect(result).toBeNull();
+	});
 });

--- a/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.ts
+++ b/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.ts
@@ -12,7 +12,7 @@ export function parseAgentResponse(text: string): AgentResponse | null {
 			typeof parsed === "object" &&
 			parsed !== null &&
 			typeof parsed.message === "string" &&
-			typeof parsed.progress === "number"
+			Number.isFinite(parsed.progress) && parsed.progress >= 0 && parsed.progress <= 100
 		) {
 			return { message: parsed.message, progress: parsed.progress };
 		}

--- a/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.ts
+++ b/apps/web/src/app/(protected)/pet/onboard/parse-agent-response.ts
@@ -1,0 +1,23 @@
+export interface AgentResponse {
+	message: string;
+	progress: number;
+}
+
+export function parseAgentResponse(text: string): AgentResponse | null {
+	if (!text) return null;
+
+	try {
+		const parsed = JSON.parse(text);
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			typeof parsed.message === "string" &&
+			typeof parsed.progress === "number"
+		) {
+			return { message: parsed.message, progress: parsed.progress };
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/web/src/app/(protected)/pet/onboard/pet-onboarding-page.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/pet-onboarding-page.tsx
@@ -40,7 +40,7 @@ export function PetOnboardingPage({ userId }: PetOnboardingPageProps) {
 	}
 
 	return (
-		<div className="flex h-[calc(100vh-4rem)] flex-col">
+		<div className="flex h-full flex-col">
 			<TypeformPanel
 				messages={messages}
 				sendMessage={sendMessage}

--- a/apps/web/src/app/(protected)/pet/onboard/pet-onboarding-page.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/pet-onboarding-page.tsx
@@ -33,10 +33,10 @@ export function PetOnboardingPage({ userId }: PetOnboardingPageProps) {
 		});
 	}, [sendMessage]);
 
-	const state = derivePetState(messages);
+	const state = useMemo(() => derivePetState(messages), [messages]);
 
 	if (state.narrative) {
-		return <PetPreviewPanel messages={messages} />;
+		return <PetPreviewPanel state={state} />;
 	}
 
 	return (

--- a/apps/web/src/app/(protected)/pet/onboard/pet-onboarding-page.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/pet-onboarding-page.tsx
@@ -3,47 +3,49 @@
 import { DefaultChatTransport } from "ai";
 import { useChat } from "@ai-sdk/react";
 import { useMemo, useEffect, useRef } from "react";
-import { ChatPanel } from "./chat-panel";
+import { TypeformPanel } from "./chat-panel";
 import { PetPreviewPanel } from "./pet-preview-panel";
+import { derivePetState } from "./derive-pet-state";
 
 interface PetOnboardingPageProps {
-  userId: string;
+	userId: string;
 }
 
 export function PetOnboardingPage({ userId }: PetOnboardingPageProps) {
-  const initiated = useRef(false);
+	const initiated = useRef(false);
 
-  const transport = useMemo(
-    () =>
-      new DefaultChatTransport({
-        api: "http://localhost:3030/chat/pet-onboarding-agent",
-        body: { resourceId: userId },
-      }),
-    [userId],
-  );
+	const transport = useMemo(
+		() =>
+			new DefaultChatTransport({
+				api: "http://localhost:3030/chat/pet-onboarding-agent",
+				body: { resourceId: userId },
+			}),
+		[userId],
+	);
 
-  const { messages, status, sendMessage } = useChat({ transport });
+	const { messages, status, sendMessage } = useChat({ transport });
 
-  useEffect(() => {
-    if (initiated.current) return;
-    initiated.current = true;
-    sendMessage({
-      text: `My user id is ${userId}, Start the conversation please`,
-    });
-  }, [sendMessage]);
+	useEffect(() => {
+		if (initiated.current) return;
+		initiated.current = true;
+		sendMessage({
+			text: `My user id is ${userId}, Start the conversation please`,
+		});
+	}, [sendMessage]);
 
-  return (
-    <div className="flex h-[calc(100vh-8rem)] gap-6 p-6">
-      <div className="flex w-1/2 flex-col">
-        <ChatPanel
-          messages={messages}
-          sendMessage={sendMessage}
-          status={status}
-        />
-      </div>
-      <div className="w-1/2">
-        <PetPreviewPanel messages={messages} />
-      </div>
-    </div>
-  );
+	const state = derivePetState(messages);
+
+	if (state.narrative) {
+		return <PetPreviewPanel messages={messages} />;
+	}
+
+	return (
+		<div className="flex h-[calc(100vh-4rem)] flex-col">
+			<TypeformPanel
+				messages={messages}
+				sendMessage={sendMessage}
+				status={status}
+			/>
+		</div>
+	);
 }

--- a/apps/web/src/app/(protected)/pet/onboard/pet-preview-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/pet-preview-panel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import type { UIMessage } from "ai";
 import { useRouter } from "next/navigation";
-import { derivePetState } from "./derive-pet-state";
+import type { PetOnboardingState } from "./derive-pet-state";
 
 const PET_EMOJI: Record<string, string> = {
   dog: "🐶",
@@ -25,9 +24,8 @@ function InfoRow({ label, value }: { label: string; value: string | null }) {
   );
 }
 
-export function PetPreviewPanel({ messages }: { messages: UIMessage[] }) {
+export function PetPreviewPanel({ state }: { state: PetOnboardingState }) {
   const router = useRouter();
-  const state = derivePetState(messages);
 
   return (
     <div className="flex h-full flex-col gap-4">

--- a/apps/web/src/app/(protected)/pet/onboard/pet-preview-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/pet-preview-panel.tsx
@@ -28,7 +28,7 @@ export function PetPreviewPanel({ state }: { state: PetOnboardingState }) {
   const router = useRouter();
 
   return (
-    <div className="flex h-full flex-col gap-4 p-6">
+    <div className="flex h-full flex-col gap-4 p-6 animate-in fade-in slide-in-from-bottom-6 duration-500">
       <div className="rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
         <h2 className="mb-4 font-semibold text-gray-900">Your Pet</h2>
         <div className="flex items-center gap-4">

--- a/apps/web/src/app/(protected)/pet/onboard/pet-preview-panel.tsx
+++ b/apps/web/src/app/(protected)/pet/onboard/pet-preview-panel.tsx
@@ -28,7 +28,7 @@ export function PetPreviewPanel({ state }: { state: PetOnboardingState }) {
   const router = useRouter();
 
   return (
-    <div className="flex h-full flex-col gap-4">
+    <div className="flex h-full flex-col gap-4 p-6">
       <div className="rounded-xl border border-gray-100 bg-white p-6 shadow-sm">
         <h2 className="mb-4 font-semibold text-gray-900">Your Pet</h2>
         <div className="flex items-center gap-4">


### PR DESCRIPTION
<!-- Add your trello card here if you want -->

---

### TL,DR
- Replaced two-column chat layout with a Typeform-style single-column onboarding flow
- Agent now returns structured JSON `{ message, progress }` to drive the UI
- Smooth transitions: slide-up entry, slide-down exit, typing dots between steps
- Pet reveal screen animates in on completion

### What happened here?

#### Typeform UI
The `/pet/onboard` page is rebuilt as a focused, full-viewport flow — one question at a time, progress bar, pinned input, and Enter to submit.

#### Structured agent responses
`border-collie` now returns `{ message, progress }` JSON on every turn. `progress` (0–100) drives the progress bar without step-counting issues. Confirmation step shows the narrative only — no trait lists or scores.

#### Transitions & polish
Questions slide up on arrival and slide down on exit. Typing dots appear while the agent is thinking. Input auto-focuses after each response. The reveal screen animates in when the pet is saved.

### How do I know this is working?
- `pnpm vitest run` — 12 tests passing
- Manual flow tested end-to-end (Mochi the Scottish Fold 🐱)

### Any notes?
- Closes #14 
- Closes #15 
- Closes #16 
- Closes #29
