### PR TITLE
feat: pet photo uploads (S3 presigned URLs)

### DIFF
--- a/apps/golden-retriever/.env.example
+++ b/apps/golden-retriever/.env.example
@@ -8,3 +8,9 @@ DATABASE_URL=postgresql://postgres:postgres@postgres:5432/golden-retriever
 
 # CORS (if adding CORS later)
 # CORS_ORIGIN=http://localhost:3000
+
+# S3 Storage
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+S3_BUCKET=pawmery-dev

--- a/apps/golden-retriever/drizzle/0004_loose_iron_fist.sql
+++ b/apps/golden-retriever/drizzle/0004_loose_iron_fist.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "pet_photos" (
+	"id" text PRIMARY KEY NOT NULL,
+	"pet_id" text NOT NULL,
+	"key" text NOT NULL,
+	"content_type" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "pet_photos_petId_idx" ON "pet_photos" USING btree ("pet_id");

--- a/apps/golden-retriever/drizzle/meta/0004_snapshot.json
+++ b/apps/golden-retriever/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,553 @@
+{
+  "id": "b8f325ea-fb38-4d80-b222-7e13a898bd72",
+  "prevId": "0cf0842d-7ff9-4ff9-a9dd-f5e869d5796f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "test_id": {
+          "name": "test_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet": {
+      "name": "pet",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "pet_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_userId_idx": {
+          "name": "pet_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pet_photos": {
+      "name": "pet_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pet_id": {
+          "name": "pet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pet_photos_petId_idx": {
+          "name": "pet_photos_petId_idx",
+          "columns": [
+            {
+              "expression": "pet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.pet_type": {
+      "name": "pet_type",
+      "schema": "public",
+      "values": [
+        "dog",
+        "cat",
+        "bird",
+        "rabbit",
+        "sheep"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/golden-retriever/drizzle/meta/_journal.json
+++ b/apps/golden-retriever/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1773473265798,
       "tag": "0003_refactor_pet_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1773980152448,
+      "tag": "0004_loose_iron_fist",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/golden-retriever/package.json
+++ b/apps/golden-retriever/package.json
@@ -23,7 +23,8 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
-    "@repo/pet-client": "workspace:*",
+    "@aws-sdk/client-s3": "^3.1013.0",
+    "@aws-sdk/s3-request-presigner": "^3.1013.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
@@ -31,6 +32,7 @@
     "@nestjs/platform-fastify": "^11.1.9",
     "@nestjs/swagger": "^11.2.3",
     "@paralleldrive/cuid2": "^3.3.0",
+    "@repo/pet-client": "workspace:*",
     "drizzle-orm": "^0.45.1",
     "js-yaml": "^4.1.1",
     "nestjs-zod": "^5.0.1",

--- a/apps/golden-retriever/package.json
+++ b/apps/golden-retriever/package.json
@@ -76,6 +76,12 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "@paralleldrive/cuid2": "<rootDir>/__mocks__/cuid2.js"
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/"
+    ]
   }
 }

--- a/apps/golden-retriever/src/__mocks__/cuid2.js
+++ b/apps/golden-retriever/src/__mocks__/cuid2.js
@@ -1,0 +1,4 @@
+"use strict";
+module.exports = {
+	createId: () => "test_cuid_id",
+};

--- a/apps/golden-retriever/src/app.module.ts
+++ b/apps/golden-retriever/src/app.module.ts
@@ -26,6 +26,7 @@ import { yamlConfigLoader } from "./config/config.loader";
 import { LoggerModule, LoggerService } from "./logger";
 import { TestModule } from "./test/test.module";
 import { PetModule } from "./pet/pet.module";
+import { StorageModule } from "./storage/storage.module";
 
 @Catch(HttpException)
 class HttpExceptionFilter extends BaseExceptionFilter {
@@ -55,6 +56,7 @@ class HttpExceptionFilter extends BaseExceptionFilter {
 		LoggerModule,
 		TestModule,
 		PetModule,
+		StorageModule,
 		ConfigModule.forRoot({
 			isGlobal: true,
 			envFilePath: ".env",

--- a/apps/golden-retriever/src/config/app-config.service.ts
+++ b/apps/golden-retriever/src/config/app-config.service.ts
@@ -37,22 +37,16 @@ export class AppConfigService {
 		);
 	}
 
-	getAwsRegion(): string {
-		const val = this.configService.get<string>("AWS_REGION");
-		if (!val) throw new Error("AWS_REGION is not set");
-		return val;
+	getAwsRegion(): string | undefined {
+		return this.configService.get<string>("AWS_REGION");
 	}
 
-	getAwsAccessKeyId(): string {
-		const val = this.configService.get<string>("AWS_ACCESS_KEY_ID");
-		if (!val) throw new Error("AWS_ACCESS_KEY_ID is not set");
-		return val;
+	getAwsAccessKeyId(): string | undefined {
+		return this.configService.get<string>("AWS_ACCESS_KEY_ID");
 	}
 
-	getAwsSecretAccessKey(): string {
-		const val = this.configService.get<string>("AWS_SECRET_ACCESS_KEY");
-		if (!val) throw new Error("AWS_SECRET_ACCESS_KEY is not set");
-		return val;
+	getAwsSecretAccessKey(): string | undefined {
+		return this.configService.get<string>("AWS_SECRET_ACCESS_KEY");
 	}
 
 	getS3Bucket(): string {

--- a/apps/golden-retriever/src/config/app-config.service.ts
+++ b/apps/golden-retriever/src/config/app-config.service.ts
@@ -36,4 +36,28 @@ export class AppConfigService {
 			DEFAULT_ENVIRONMENT
 		);
 	}
+
+	getAwsRegion(): string {
+		const val = this.configService.get<string>("AWS_REGION");
+		if (!val) throw new Error("AWS_REGION is not set");
+		return val;
+	}
+
+	getAwsAccessKeyId(): string {
+		const val = this.configService.get<string>("AWS_ACCESS_KEY_ID");
+		if (!val) throw new Error("AWS_ACCESS_KEY_ID is not set");
+		return val;
+	}
+
+	getAwsSecretAccessKey(): string {
+		const val = this.configService.get<string>("AWS_SECRET_ACCESS_KEY");
+		if (!val) throw new Error("AWS_SECRET_ACCESS_KEY is not set");
+		return val;
+	}
+
+	getS3Bucket(): string {
+		const val = this.configService.get<string>("S3_BUCKET");
+		if (!val) throw new Error("S3_BUCKET is not set");
+		return val;
+	}
 }

--- a/apps/golden-retriever/src/db/schema/index.ts
+++ b/apps/golden-retriever/src/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from "./test";
 export * from "./auth-schema";
 export * from "../../pet/pet.schema";
+export * from "../../pet/photo.schema";

--- a/apps/golden-retriever/src/pet/pet.dto.ts
+++ b/apps/golden-retriever/src/pet/pet.dto.ts
@@ -14,3 +14,15 @@ export class GetPetDto extends createZodDto(GetPetSchema) {}
 export class UpdatePetDto extends createZodDto(UpdatePetSchema) {}
 export class DeletePetDto extends createZodDto(DeletePetSchema) {}
 export class PetResponseDto extends createZodDto(PetSchema) {}
+
+import {
+	GetPhotoUploadUrlSchema,
+	AddPhotoSchema,
+	PhotoUploadUrlSchema,
+	PetPhotoSchema,
+} from "@repo/pet-client";
+
+export class GetPhotoUploadUrlDto extends createZodDto(GetPhotoUploadUrlSchema) {}
+export class AddPhotoDto extends createZodDto(AddPhotoSchema) {}
+export class PhotoUploadUrlResponseDto extends createZodDto(PhotoUploadUrlSchema) {}
+export class PetPhotoResponseDto extends createZodDto(PetPhotoSchema) {}

--- a/apps/golden-retriever/src/pet/pet.module.ts
+++ b/apps/golden-retriever/src/pet/pet.module.ts
@@ -2,9 +2,13 @@ import { Module } from "@nestjs/common";
 import { PetController } from "./pet.controller";
 import { PetRepository } from "./pet.repository";
 import { PetService } from "./pet.service";
+import { PhotoController } from "./photo.controller";
+import { PhotoRepository } from "./photo.repository";
+import { PhotoService } from "./photo.service";
 
 @Module({
-	controllers: [PetController],
-	providers: [PetRepository, PetService],
+	controllers: [PetController, PhotoController],
+	providers: [PetRepository, PetService, PhotoRepository, PhotoService],
+	exports: [PetService],
 })
 export class PetModule {}

--- a/apps/golden-retriever/src/pet/photo.controller.spec.ts
+++ b/apps/golden-retriever/src/pet/photo.controller.spec.ts
@@ -1,0 +1,38 @@
+jest.mock("./photo.service", () => ({ PhotoService: class {} }));
+
+import { Test, type TestingModule } from "@nestjs/testing";
+import { PhotoController } from "./photo.controller";
+import { PhotoService } from "./photo.service";
+
+const mockResult = { uploadUrl: "https://s3.example.com/key?sig=1", key: "pets/pet_1/abc.jpg" };
+const mockPhoto = { id: "photo_1", petId: "pet_1", key: "pets/pet_1/abc.jpg", contentType: "image/jpeg", createdAt: new Date() };
+
+const mockService = {
+	getUploadUrl: jest.fn().mockResolvedValue(mockResult),
+	addPhoto: jest.fn().mockResolvedValue(mockPhoto),
+};
+
+describe("PhotoController", () => {
+	let controller: PhotoController;
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [PhotoController],
+			providers: [{ provide: PhotoService, useValue: mockService }],
+		}).compile();
+		controller = module.get<PhotoController>(PhotoController);
+	});
+
+	it("POST /pet/:id/photos/upload-url", async () => {
+		const result = await controller.getUploadUrl("pet_1", { userId: "user_1", contentType: "image/jpeg" });
+		expect(result).toEqual(mockResult);
+		expect(mockService.getUploadUrl).toHaveBeenCalledWith("pet_1", "user_1", "image/jpeg");
+	});
+
+	it("PATCH /pet/:id/photos", async () => {
+		const result = await controller.addPhoto("pet_1", { userId: "user_1", key: "pets/pet_1/abc.jpg", contentType: "image/jpeg" });
+		expect(result).toEqual(mockPhoto);
+		expect(mockService.addPhoto).toHaveBeenCalledWith("pet_1", "user_1", "pets/pet_1/abc.jpg", "image/jpeg");
+	});
+});

--- a/apps/golden-retriever/src/pet/photo.controller.ts
+++ b/apps/golden-retriever/src/pet/photo.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Param, Patch, Post } from "@nestjs/common";
+import { PhotoService } from "./photo.service";
+import { GetPhotoUploadUrlDto, AddPhotoDto } from "./pet.dto";
+
+@Controller("pet")
+export class PhotoController {
+	constructor(private readonly service: PhotoService) {}
+
+	@Post(":id/photos/upload-url")
+	getUploadUrl(@Param("id") id: string, @Body() dto: GetPhotoUploadUrlDto) {
+		return this.service.getUploadUrl(id, dto.userId, dto.contentType);
+	}
+
+	@Patch(":id/photos")
+	addPhoto(@Param("id") id: string, @Body() dto: AddPhotoDto) {
+		return this.service.addPhoto(id, dto.userId, dto.key, dto.contentType);
+	}
+}

--- a/apps/golden-retriever/src/pet/photo.repository.ts
+++ b/apps/golden-retriever/src/pet/photo.repository.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { eq } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { DRIZZLE } from "../db/db.constants";
+import * as schema from "../db/schema";
+import { petPhoto } from "./photo.schema";
+
+@Injectable()
+export class PhotoRepository {
+	constructor(
+		@Inject(DRIZZLE)
+		private readonly db: NodePgDatabase<typeof schema>,
+	) {}
+
+	async create(petId: string, key: string, contentType: string) {
+		const [created] = await this.db
+			.insert(petPhoto)
+			.values({ petId, key, contentType })
+			.returning();
+		return created;
+	}
+
+	async findAllByPet(petId: string) {
+		return this.db.select().from(petPhoto).where(eq(petPhoto.petId, petId));
+	}
+}

--- a/apps/golden-retriever/src/pet/photo.schema.ts
+++ b/apps/golden-retriever/src/pet/photo.schema.ts
@@ -1,0 +1,18 @@
+import { pgTable, text, timestamp, index } from "drizzle-orm/pg-core";
+import { createId } from "@paralleldrive/cuid2";
+
+export const petPhoto = pgTable(
+	"pet_photos",
+	{
+		id: text("id")
+			.primaryKey()
+			.$defaultFn(() => createId()),
+		petId: text("pet_id").notNull(),
+		key: text("key").notNull(),
+		contentType: text("content_type").notNull(),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [index("pet_photos_petId_idx").on(table.petId)],
+);

--- a/apps/golden-retriever/src/pet/photo.service.spec.ts
+++ b/apps/golden-retriever/src/pet/photo.service.spec.ts
@@ -1,0 +1,56 @@
+jest.mock("./photo.repository", () => ({ PhotoRepository: class {} }));
+jest.mock("./pet.service", () => ({ PetService: class {} }));
+jest.mock("../storage/storage.service", () => ({ StorageService: class {} }));
+
+import { Test, type TestingModule } from "@nestjs/testing";
+import { PhotoService } from "./photo.service";
+import { PhotoRepository } from "./photo.repository";
+import { PetService } from "./pet.service";
+import { StorageService } from "../storage/storage.service";
+
+const mockPhoto = {
+	id: "photo_1",
+	petId: "pet_1",
+	key: "pets/pet_1/abc.jpg",
+	contentType: "image/jpeg",
+	createdAt: new Date(),
+};
+const mockSignedUrl = "https://s3.amazonaws.com/bucket/pets/pet_1/abc.jpg?signed=1";
+
+const mockPetService = { get: jest.fn().mockResolvedValue({ id: "pet_1", userId: "user_1" }) };
+const mockPhotoRepo = { create: jest.fn().mockResolvedValue(mockPhoto) };
+const mockStorage = { presignUpload: jest.fn().mockResolvedValue(mockSignedUrl) };
+
+describe("PhotoService", () => {
+	let service: PhotoService;
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				PhotoService,
+				{ provide: PhotoRepository, useValue: mockPhotoRepo },
+				{ provide: PetService, useValue: mockPetService },
+				{ provide: StorageService, useValue: mockStorage },
+			],
+		}).compile();
+		service = module.get<PhotoService>(PhotoService);
+	});
+
+	it("getUploadUrl — verifies ownership and returns url + key", async () => {
+		const result = await service.getUploadUrl("pet_1", "user_1", "image/jpeg");
+		expect(mockPetService.get).toHaveBeenCalledWith("pet_1", "user_1");
+		expect(mockStorage.presignUpload).toHaveBeenCalledTimes(1);
+		expect(result).toMatchObject({
+			uploadUrl: mockSignedUrl,
+			key: expect.stringContaining("pets/pet_1/"),
+		});
+	});
+
+	it("addPhoto — verifies ownership and persists record", async () => {
+		const result = await service.addPhoto("pet_1", "user_1", "pets/pet_1/abc.jpg", "image/jpeg");
+		expect(mockPetService.get).toHaveBeenCalledWith("pet_1", "user_1");
+		expect(mockPhotoRepo.create).toHaveBeenCalledWith("pet_1", "pets/pet_1/abc.jpg", "image/jpeg");
+		expect(result).toEqual(mockPhoto);
+	});
+});

--- a/apps/golden-retriever/src/pet/photo.service.ts
+++ b/apps/golden-retriever/src/pet/photo.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from "@nestjs/common";
+import { createId } from "@paralleldrive/cuid2";
+import { PhotoRepository } from "./photo.repository";
+import { PetService } from "./pet.service";
+import { StorageService } from "../storage/storage.service";
+
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+	"image/jpeg": "jpg",
+	"image/png": "png",
+	"image/webp": "webp",
+	"image/gif": "gif",
+};
+
+@Injectable()
+export class PhotoService {
+	constructor(
+		private readonly repo: PhotoRepository,
+		private readonly petService: PetService,
+		private readonly storage: StorageService,
+	) {}
+
+	async getUploadUrl(petId: string, userId: string, contentType: string) {
+		await this.petService.get(petId, userId);
+		const ext = CONTENT_TYPE_TO_EXT[contentType] ?? "bin";
+		const key = `pets/${petId}/${createId()}.${ext}`;
+		const uploadUrl = await this.storage.presignUpload(key, contentType, 300);
+		return { uploadUrl, key };
+	}
+
+	async addPhoto(petId: string, userId: string, key: string, contentType: string) {
+		await this.petService.get(petId, userId);
+		return this.repo.create(petId, key, contentType);
+	}
+}

--- a/apps/golden-retriever/src/storage/storage.module.ts
+++ b/apps/golden-retriever/src/storage/storage.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from "@nestjs/common";
+import { StorageService } from "./storage.service";
+import { AppConfigService } from "../config/app-config.service";
+
+@Global()
+@Module({
+	providers: [StorageService, AppConfigService],
+	exports: [StorageService],
+})
+export class StorageModule {}

--- a/apps/golden-retriever/src/storage/storage.service.spec.ts
+++ b/apps/golden-retriever/src/storage/storage.service.spec.ts
@@ -1,0 +1,42 @@
+jest.mock("@aws-sdk/client-s3");
+jest.mock("@aws-sdk/s3-request-presigner");
+
+import { Test, type TestingModule } from "@nestjs/testing";
+import { StorageService } from "./storage.service";
+import { AppConfigService } from "../config/app-config.service";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+const mockConfig = {
+	getAwsRegion: jest.fn().mockReturnValue("us-east-1"),
+	getAwsAccessKeyId: jest.fn().mockReturnValue("test-key"),
+	getAwsSecretAccessKey: jest.fn().mockReturnValue("test-secret"),
+	getS3Bucket: jest.fn().mockReturnValue("pawmery-dev"),
+};
+
+const mockSignedUrl = "https://s3.amazonaws.com/pawmery-dev/pets/pet_1/abc.jpg?signed=1";
+
+describe("StorageService", () => {
+	let service: StorageService;
+
+	beforeEach(async () => {
+		jest.clearAllMocks();
+		(getSignedUrl as jest.Mock).mockResolvedValue(mockSignedUrl);
+
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				StorageService,
+				{ provide: AppConfigService, useValue: mockConfig },
+			],
+		}).compile();
+
+		service = module.get<StorageService>(StorageService);
+	});
+
+	describe("presignUpload", () => {
+		it("should return a signed URL", async () => {
+			const url = await service.presignUpload("pets/pet_1/abc.jpg", "image/jpeg", 300);
+			expect(url).toBe(mockSignedUrl);
+			expect(getSignedUrl).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/apps/golden-retriever/src/storage/storage.service.ts
+++ b/apps/golden-retriever/src/storage/storage.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import type { S3ClientConfig } from "@aws-sdk/client-s3";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { AppConfigService } from "../config/app-config.service";
@@ -9,13 +10,18 @@ export class StorageService {
 	private readonly bucket: string;
 
 	constructor(private readonly config: AppConfigService) {
-		this.client = new S3Client({
-			region: config.getAwsRegion(),
-			credentials: {
-				accessKeyId: config.getAwsAccessKeyId(),
-				secretAccessKey: config.getAwsSecretAccessKey(),
-			},
-		});
+		const clientConfig: S3ClientConfig = {};
+
+		const region = config.getAwsRegion();
+		if (region) clientConfig.region = region;
+
+		const accessKeyId = config.getAwsAccessKeyId();
+		const secretAccessKey = config.getAwsSecretAccessKey();
+		if (accessKeyId && secretAccessKey) {
+			clientConfig.credentials = { accessKeyId, secretAccessKey };
+		}
+
+		this.client = new S3Client(clientConfig);
 		this.bucket = config.getS3Bucket();
 	}
 

--- a/apps/golden-retriever/src/storage/storage.service.ts
+++ b/apps/golden-retriever/src/storage/storage.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { AppConfigService } from "../config/app-config.service";
+
+@Injectable()
+export class StorageService {
+	private readonly client: S3Client;
+	private readonly bucket: string;
+
+	constructor(private readonly config: AppConfigService) {
+		this.client = new S3Client({
+			region: config.getAwsRegion(),
+			credentials: {
+				accessKeyId: config.getAwsAccessKeyId(),
+				secretAccessKey: config.getAwsSecretAccessKey(),
+			},
+		});
+		this.bucket = config.getS3Bucket();
+	}
+
+	presignUpload(key: string, contentType: string, expiresIn: number): Promise<string> {
+		const command = new PutObjectCommand({
+			Bucket: this.bucket,
+			Key: key,
+			ContentType: contentType,
+		});
+		return getSignedUrl(this.client, command, { expiresIn });
+	}
+}

--- a/packages/pet-client/src/client.ts
+++ b/packages/pet-client/src/client.ts
@@ -2,6 +2,8 @@ import type {
   CreatePetInput,
   UpdatePetInput,
   Pet,
+  PhotoUploadUrl,
+  PetPhoto,
 } from "./types";
 
 export class PetClient {
@@ -49,5 +51,13 @@ export class PetClient {
 
   remove(id: string, userId: string) {
     return this.request<void>(`/pet/${id}`, "DELETE", { userId });
+  }
+
+  getPhotoUploadUrl(petId: string, dto: { userId: string; contentType: string }) {
+    return this.request<PhotoUploadUrl>(`/pet/${petId}/photos/upload-url`, "POST", dto);
+  }
+
+  addPhoto(petId: string, dto: { userId: string; key: string; contentType: string }) {
+    return this.request<PetPhoto>(`/pet/${petId}/photos`, "PATCH", dto);
   }
 }

--- a/packages/pet-client/src/schemas.ts
+++ b/packages/pet-client/src/schemas.ts
@@ -38,3 +38,27 @@ export const PetSchema = z.object({
 	createdAt: z.coerce.date(),
 	updatedAt: z.coerce.date(),
 });
+
+export const GetPhotoUploadUrlSchema = z.object({
+	userId: z.string().min(1),
+	contentType: z.string().min(1),
+});
+
+export const AddPhotoSchema = z.object({
+	userId: z.string().min(1),
+	key: z.string().min(1),
+	contentType: z.string().min(1),
+});
+
+export const PhotoUploadUrlSchema = z.object({
+	uploadUrl: z.string().url(),
+	key: z.string().min(1),
+});
+
+export const PetPhotoSchema = z.object({
+	id: z.string(),
+	petId: z.string(),
+	key: z.string(),
+	contentType: z.string(),
+	createdAt: z.coerce.date(),
+});

--- a/packages/pet-client/src/types.ts
+++ b/packages/pet-client/src/types.ts
@@ -4,9 +4,17 @@ import type {
 	UpdatePetSchema,
 	PetSchema,
 	PetTypeSchema,
+	GetPhotoUploadUrlSchema,
+	AddPhotoSchema,
+	PhotoUploadUrlSchema,
+	PetPhotoSchema,
 } from "./schemas";
 
 export type PetType = z.infer<typeof PetTypeSchema>;
 export type Pet = z.infer<typeof PetSchema>;
 export type CreatePetInput = z.infer<typeof CreatePetSchema>;
 export type UpdatePetInput = z.infer<typeof UpdatePetSchema>;
+export type GetPhotoUploadUrlInput = z.infer<typeof GetPhotoUploadUrlSchema>;
+export type AddPhotoInput = z.infer<typeof AddPhotoSchema>;
+export type PhotoUploadUrl = z.infer<typeof PhotoUploadUrlSchema>;
+export type PetPhoto = z.infer<typeof PetPhotoSchema>;


### PR DESCRIPTION
### TL,DR

- Add presigned S3 upload URL endpoint for pet photos
- Add endpoint to persist confirmed photo uploads
- New `pet_photos` table with Drizzle migration
- AWS credential chain support (explicit creds optional, falls back to AWS CLI profile)
- `@repo/pet-client` updated with photo upload bindings

### What happened here?

A new `StorageModule` wraps the AWS S3 SDK and is registered globally in golden-retriever. It reads `S3_BUCKET` as required config; `AWS_REGION` and credentials are optional and fall back to the AWS credential chain (e.g. local AWS CLI profile).

Two new endpoints are added to the pet service: `POST /pet/:id/photos/upload-url` returns a short-lived presigned PUT URL the client can use to upload directly to S3, and `PATCH /pet/:id/photos` persists the confirmed S3 key into a new `pet_photos` table. Both verify pet ownership before proceeding.

### How do I know this is working?

- 22 tests passing (`pnpm test` in `apps/golden-retriever`)
- Typecheck clean (`pnpm typecheck`)
- Manual: add `S3_BUCKET=pawmery-dev` to `.env`, start the service, `POST /pet/:id/photos/upload-url` with `{ userId, contentType }`, PUT a file to the returned URL, then `PATCH /pet/:id/photos` with the returned key

### Any notes?

- UX (photo upload in onboarding/profile) is deferred to #32
- `S3_BUCKET` is the only required env var; AWS CLI profile covers auth locally
