### PR TITLE
ci(docker): add border-collie Dockerfile and fix golden-retriever port

### DIFF
--- a/apps/border-collie/.dockerignore
+++ b/apps/border-collie/.dockerignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules
+npm-debug.log
+pnpm-debug.log
+yarn-error.log
+
+# Build outputs
+dist
+.mastra
+.turbo
+
+# Testing
+coverage
+.nyc_output
+*.log
+
+# Environment files
+.env
+.env.local
+.env.*.local
+.env.development
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git
+.gitignore
+
+# Documentation
+*.md
+!README.md
+
+# Docker
+Dockerfile
+.dockerignore

--- a/apps/border-collie/Dockerfile
+++ b/apps/border-collie/Dockerfile
@@ -1,0 +1,46 @@
+FROM node:22-alpine AS base
+ARG APP_NAME=border-collie
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+FROM base AS builder
+RUN apk update
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+RUN pnpm install -g turbo@^2
+COPY . .
+
+RUN turbo prune $APP_NAME --docker
+
+FROM base AS installer
+RUN apk update
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+COPY --from=builder /app/out/json/ .
+RUN pnpm install --frozen-lockfile
+
+COPY --from=builder /app/out/full/ .
+RUN pnpm turbo run build --filter=$APP_NAME
+
+FROM base AS runner
+WORKDIR /app
+
+ENV APP_NAME=$APP_NAME
+ENV NODE_ENV=production
+ENV PORT=4111
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 mastra
+
+# .mastra/output is self-contained (includes its own node_modules)
+COPY --from=installer --chown=mastra:nodejs /app/apps/$APP_NAME/.mastra/output ./output
+
+USER mastra
+
+EXPOSE 4111
+
+CMD ["node", "output/index.mjs"]

--- a/apps/border-collie/Dockerfile
+++ b/apps/border-collie/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:22-alpine AS base
-ARG APP_NAME=border-collie
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
 FROM base AS builder
+ARG APP_NAME=border-collie
 RUN apk update
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -16,6 +16,7 @@ COPY . .
 RUN turbo prune $APP_NAME --docker
 
 FROM base AS installer
+ARG APP_NAME=border-collie
 RUN apk update
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -27,9 +28,9 @@ COPY --from=builder /app/out/full/ .
 RUN pnpm turbo run build --filter=$APP_NAME
 
 FROM base AS runner
+ARG APP_NAME=border-collie
 WORKDIR /app
 
-ENV APP_NAME=$APP_NAME
 ENV NODE_ENV=production
 ENV PORT=4111
 
@@ -39,8 +40,15 @@ RUN adduser --system --uid 1001 mastra
 # .mastra/output is self-contained (includes its own node_modules)
 COPY --from=installer --chown=mastra:nodejs /app/apps/$APP_NAME/.mastra/output ./output
 
+# @repo/pet-client is a workspace dependency not bundled by mastra build
+COPY --from=installer --chown=mastra:nodejs /app/packages/pet-client/dist ./packages/pet-client/dist
+COPY --from=installer --chown=mastra:nodejs /app/packages/pet-client/package.json ./packages/pet-client/package.json
+
 USER mastra
 
 EXPOSE 4111
 
-CMD ["node", "output/index.mjs"]
+# Run from /app/output so that relative paths (e.g. ./mastra.db) resolve
+# to a directory owned by the mastra user
+WORKDIR /app/output
+CMD ["node", "index.mjs"]

--- a/apps/golden-retriever/Dockerfile
+++ b/apps/golden-retriever/Dockerfile
@@ -1,11 +1,11 @@
 FROM node:22-alpine AS base
-ARG APP_NAME=golden-retriever
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
 FROM base AS builder
+ARG APP_NAME=golden-retriever
 RUN apk update
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -16,6 +16,7 @@ COPY . .
 RUN turbo prune $APP_NAME --docker
 
 FROM base AS installer
+ARG APP_NAME=golden-retriever
 RUN apk update
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -27,10 +28,10 @@ COPY --from=builder /app/out/full/ .
 RUN pnpm turbo run build --filter=$APP_NAME
 
 FROM base AS runner
+ARG APP_NAME=golden-retriever
 WORKDIR /app
 
-ENV APP_NAME=$APP_NAME
-ENV NODE_ENV=development
+ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 
 RUN addgroup --system --gid 1001 nodejs
@@ -40,6 +41,10 @@ COPY --from=installer --chown=nestjs:nodejs /app/node_modules ./node_modules
 COPY --from=installer --chown=nestjs:nodejs /app/apps/$APP_NAME/node_modules ./apps/$APP_NAME/node_modules
 COPY --from=installer --chown=nestjs:nodejs /app/package.json ./package.json
 
+COPY --from=installer --chown=nestjs:nodejs /app/packages/pet-client/dist ./packages/pet-client/dist
+COPY --from=installer --chown=nestjs:nodejs /app/packages/pet-client/package.json ./packages/pet-client/package.json
+COPY --from=installer --chown=nestjs:nodejs /app/packages/pet-client/node_modules ./packages/pet-client/node_modules
+
 COPY --from=installer --chown=nestjs:nodejs /app/apps/$APP_NAME/dist ./apps/$APP_NAME/dist
 COPY --from=installer --chown=nestjs:nodejs /app/apps/$APP_NAME/package.json ./apps/$APP_NAME/package.json
 
@@ -48,4 +53,4 @@ USER nestjs
 EXPOSE 3020
 
 WORKDIR /app/apps/$APP_NAME
-CMD ["node", "dist/main.js"]
+CMD ["node", "dist/src/main.js"]

--- a/apps/golden-retriever/Dockerfile
+++ b/apps/golden-retriever/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=installer --chown=nestjs:nodejs /app/apps/$APP_NAME/package.json ./a
 
 USER nestjs
 
-EXPOSE 3010
+EXPOSE 3020
 
 WORKDIR /app/apps/$APP_NAME
 CMD ["node", "dist/main.js"]

--- a/apps/golden-retriever/docker-compose.yml
+++ b/apps/golden-retriever/docker-compose.yml
@@ -8,12 +8,12 @@ services:
     image: golden-retriever:latest
     container_name: golden-retriever
     ports:
-      - "3010:3010"
+      - "3020:3020"
     env_file:
       - .env
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3010/"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3020/health"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
- Add Dockerfile and .dockerignore for apps/border-collie (Mastra agent)
  - Uses turbo prune + mastra build, outputs to .mastra/output/index.mjs
  - Exposes port 4111 (Mastra default)
- Fix apps/golden-retriever Dockerfile: EXPOSE 3010 → 3020 to match PORT env
- Fix apps/golden-retriever docker-compose.yml: ports and healthcheck 3010 → 3020

Closes #18 (partial — Dockerfiles ready, CI pipeline workflow TBD)

<!-- Add your trello card here if you want -->

---

### TL,DR

### What happened here?

### How do I know this is working?

### Any notes?
